### PR TITLE
Remember selected input device / short tap for toggle

### DIFF
--- a/PushToTalk/HotKey.swift
+++ b/PushToTalk/HotKey.swift
@@ -71,13 +71,6 @@ class HotKey {
         microphone.status = MicrophoneStatus.HotKeySet
     }
 
-    func checkForDoubleTap() {
-        let timeInterval = NSDate().timeIntervalSince1970
-        let timediff = timeInterval - self.previousEpoc
-        self.previousEpoc = timeInterval
-        self.doubletap = timediff < 0.2
-    }
-
     internal func handleFlagChangedEvent(_ theEvent: NSEvent!) {
         if self.recordingHotKey {
             self.recordingHotKey = false
@@ -94,12 +87,18 @@ class HotKey {
         guard self.enabled else { return }
 
         if theEvent.modifierFlags.contains(self.modifierFlags) {
-            checkForDoubleTap()
+            if microphone.status != .Speaking {
+                let timeInterval = NSDate().timeIntervalSince1970
+                self.previousEpoc = timeInterval
+            }
+
             microphone.status = .Speaking
         } else {
-            if (!self.doubletap) {
+            let timeInterval = NSDate().timeIntervalSince1970
+            let timediff = timeInterval - self.previousEpoc
+            // Only mute on keyup when we pressed long enough so short tap is toggling the state
+            if timediff > 0.2 {
                 microphone.status = .Muted
-                doubletap = false
             }
         }
     }

--- a/PushToTalk/Microphone.swift
+++ b/PushToTalk/Microphone.swift
@@ -33,10 +33,35 @@ class Microphone {
         }
     }
     
+    func getDefaultInputDevice() -> AudioDeviceID {
+        var propertySize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var deviceID = kAudioDeviceUnknown
+        
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyDefaultInputDevice),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+        
+        AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &propertyAddress, 0, nil, &propertySize, &deviceID)
+        
+        return deviceID
+    }
+
     func setupDeviceMenu(menu: NSMenu) throws {
         menu.removeAllItems()
         let devices = try? getInputDevices()
 
+        let selectedInputId = getDefaultInputDevice()
+
+        Swift.print("Looking for device ID '\(selectedInputId)'")
+        for device in devices! {
+            if device.id == selectedInputId {
+                self.selectedInput = device
+                Swift.print("Selecting device with ID '\(selectedInputId)'")
+            }
+        }
+
+        /*
         if UserDefaults.standard.integer(forKey: "prefSelectedInputId") != nil {
             let selectedInputId = UInt32(UserDefaults.standard.integer(forKey: "prefSelectedInputId"))
 
@@ -51,6 +76,7 @@ class Microphone {
         if self.selectedInput == nil { 
             self.selectedInput = devices![0]
         }
+        */
 
         for device in devices! {
             let item = DeviceMenuItem()

--- a/PushToTalk/Microphone.swift
+++ b/PushToTalk/Microphone.swift
@@ -36,7 +36,22 @@ class Microphone {
     func setupDeviceMenu(menu: NSMenu) throws {
         menu.removeAllItems()
         let devices = try? getInputDevices()
-        self.selectedInput = devices![0]
+
+        if UserDefaults.standard.integer(forKey: "prefSelectedInputId") != nil {
+            let selectedInputId = UInt32(UserDefaults.standard.integer(forKey: "prefSelectedInputId"))
+
+            Swift.print("Looking for device ID '\(selectedInputId)'")
+            for device in devices! {
+                if device.id == selectedInputId {
+                    self.selectedInput = device
+                    Swift.print("Selecting device with ID '\(selectedInputId)'")
+                }
+            }
+        }
+        if self.selectedInput == nil { 
+            self.selectedInput = devices![0]
+        }
+
         for device in devices! {
             let item = DeviceMenuItem()
             item.inputDevice = device
@@ -59,6 +74,9 @@ class Microphone {
         }
         item.state = NSControl.StateValue.on
         self.selectedInput = item.inputDevice;
+        let inputId = self.selectedInput!;
+        Swift.print("Selecting '\(inputId.id)'")
+        UserDefaults.standard.set(inputId.id, forKey: "prefSelectedInputId")
         self.status = status
     }
 }


### PR DESCRIPTION
Hi,
not sure if you would really want to merge this PR, but these are 2 small patches I made for my personal use of this app.
It's the first time I have worked with Swift so things might be not very good.

First is to remember the selected device by using the device ID and storing it like the selected hotkey is stored.
Second is to use short taps for toggling the mute status instead of double tapping.